### PR TITLE
Fix bug: on even number of slides in center mode, extra slide gets active 

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2332,12 +2332,13 @@
             var evenCoef = _.options.slidesToShow % 2 === 0 ? 1 : 0;
 
             centerOffset = Math.floor(_.options.slidesToShow / 2);
+            var even = _.options.slidesToShow % 2 == 0;
 
             if (_.options.infinite === true) {
 
                 if (index >= centerOffset && index <= (_.slideCount - 1) - centerOffset) {
                     _.$slides
-                        .slice(index - centerOffset + evenCoef, index + centerOffset + 1)
+                        .slice(index - centerOffset, index + centerOffset + (even ? 0 : 1))
                         .addClass('slick-active')
                         .attr('aria-hidden', 'false');
 
@@ -2345,7 +2346,7 @@
 
                     indexOffset = _.options.slidesToShow + index;
                     allSlides
-                        .slice(indexOffset - centerOffset + 1 + evenCoef, indexOffset + centerOffset + 2)
+                        .slice(indexOffset - centerOffset + 1, indexOffset + centerOffset + (even ? 1 : 2))
                         .addClass('slick-active')
                         .attr('aria-hidden', 'false');
 


### PR DESCRIPTION
Applied the patch from @weberml2 https://github.com/weberml2/slick/commit/1b29b453388afa9ea2275d71ab5909dac4dc3c82 to latest version.

See https://github.com/kenwheeler/slick/issues/1571

Would be great if you could apply this pull request in your next version.